### PR TITLE
Update CI workflow, .gitignore, .helmignore, and renovate.json

### DIFF
--- a/.github/workflows/helm-unittest.yaml
+++ b/.github/workflows/helm-unittest.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: Helm unittest CI
 
 on: [push]
 
@@ -19,21 +19,21 @@ jobs:
           fi
       - run: helm unittest -t JUnit -o test-output.xml . 
       - run: helm lint .
-      - name: Helm validation and helmunit tests succeeded
+      - name: Helm validation and helm unittests succeeded
         if: ${{ success() && contains( github.ref, 'renovate/' ) && !env.ACT }}
         uses: jdcargile/ms-teams-notification@v1.4
         with:
           github-token: ${{ github.token }}
           ms-teams-webhook-uri: ${{ secrets.STEADOPS_HELM_RENOVATION_MS_TEAMS_WEBHOOK }}
-          notification-summary: "&#x2705; Helm validation and unit tests succeeded!"
+          notification-summary: "&#x2705; Helm validation and helm unittests succeeded!"
           notification-color: 28a745
           timezone: Europe/Berlin
-      - name: Helm validation or helmunit tests failed
+      - name: Helm validation or helm unittests failed
         if: ${{ failure() && contains( github.ref, 'renovate/' ) && !env.ACT }}
         uses: jdcargile/ms-teams-notification@v1.4
         with:
           github-token: ${{ github.token }}
           ms-teams-webhook-uri: ${{ secrets.STEADOPS_HELM_RENOVATION_MS_TEAMS_WEBHOOK }}
-          notification-summary: "&#x1F6A2; Helm validation or helmunit tests failed!!!"
+          notification-summary: "&#x1F6A2; Helm validation or helm unittests failed!!!"
           notification-color: dc3545
           timezone: Europe/Berlin

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
-/.project
-/_local/
+local-ca.*
+.vscode
+*.swp
+.project
+_local
+tests/__snapshot__/
+/test-output.xml

--- a/.helmignore
+++ b/.helmignore
@@ -1,0 +1,4 @@
+.*/
+.helmignore
+.gitignore
+tests

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:recommended",
     ":dependencyDashboard"
   ],
   "postUpdateOptions": [


### PR DESCRIPTION
This pull request includes several changes to improve the CI workflow, update the `.helmignore` file, and modify the `renovate.json` configuration. The most important changes are as follows:

CI Workflow Improvements:
* [`.github/workflows/helm-unittest.yaml`](diffhunk://#diff-dd184113118a7e45df053335c3b67aed9d54b00ccdff095d429b188ee387dc7dL1-R1): Renamed the workflow from "CI" to "Helm unittest CI" for better clarity.
* [`.github/workflows/helm-unittest.yaml`](diffhunk://#diff-dd184113118a7e45df053335c3b67aed9d54b00ccdff095d429b188ee387dc7dL28-R28): Updated the notification summary to distinguish between Helm validation and helm unittests.

Configuration Updates:
* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L4-R4): Changed the Renovate configuration from "config:base" to "config:recommended" for improved dependency management.

Ignore File Updates:
* [`.helmignore`](diffhunk://#diff-cccd25e8de2c349869aa46571e8cef1071452b57bce86efde5f30602926ecd59R1-R4): Added patterns to ignore hidden files, `.helmignore`, `.gitignore`, and the `tests` directory.