### PR TITLE
Add ACME domain configuration for k8s03-dev environment

### DIFF
--- a/values-sf-k8s03-dev.yaml
+++ b/values-sf-k8s03-dev.yaml
@@ -1,0 +1,3 @@
+global:
+  acme:
+    domain: k8s03-dev.steadforce.com


### PR DESCRIPTION
This pull request introduces a configuration update to the `values-sf-k8s03-dev.yaml` file, specifying the ACME domain for the development environment.

Configuration updates:

* Set the `global.acme.domain` value to `k8s03-dev.steadforce.com` in `values-sf-k8s03-dev.yaml` to configure the ACME domain for this environment.